### PR TITLE
Reorganize text replacements to avoid early match

### DIFF
--- a/Source/content_script.js
+++ b/Source/content_script.js
@@ -17,18 +17,18 @@ for (var i = 0; i < elements.length; i++) {
         if (node.nodeType === 3) {
             var text = node.nodeValue;
 
-            text = text.replace(/Hacker/, 'Password getter');
-            text = text.replace(/Hackers/, 'Password getters');
-            text = text.replace(/hacker/, 'password getter');
-            text = text.replace(/hackers/, 'password getters');
-            text = text.replace(/hacked/, 'got the password');
-            text = text.replace(/Hacked/, 'Got the password');
-            text = text.replace(/hack/, 'password get');
-            text = text.replace(/Hack/, 'Password get');
-            text = text.replace(/hacks/, 'password gets');
-            text = text.replace(/Hacks/, 'Password gets');
             text = text.replace(/hacking/, 'password getting');
             text = text.replace(/Hacking/, 'Password getting');
+//             text = text.replace(/hackers/, 'password getters');
+//             text = text.replace(/Hackers/, 'Password getters');
+            text = text.replace(/hacker/, 'password getter');
+            text = text.replace(/Hacker/, 'Password getter');
+            text = text.replace(/hacked/, 'got the password');
+            text = text.replace(/Hacked/, 'Got the password');
+//             text = text.replace(/hacks/, 'password gets');
+//             text = text.replace(/Hacks/, 'Password gets');
+            text = text.replace(/hack/, 'password get');
+            text = text.replace(/Hack/, 'Password get');
 
             node.nodeValue = text;
         }


### PR DESCRIPTION
Replacement for "password get" should come after "got the password", or else "hacked" would never be matched.

Commented out replacements for plural versions, they should match anyway.

Protip: don't leave this extension enabled while looking at github's diffs on this code.  They become very confusing.
